### PR TITLE
Add necessary changes to compile jni for android + sample Android.mk file

### DIFF
--- a/jni/build/android/Android.mk
+++ b/jni/build/android/Android.mk
@@ -1,0 +1,68 @@
+#BUILD WITH:
+#
+# NDK_PROJECT_PATH=FULL_PATH/opensc-java/jni/src/ ndk-build -C FULL_PATH/opensc-java/jni/src -j4 NDK_APPLICATION_MK=FULL_PATH/opensc-java/jni/build/android/Application.mk -B V=1 NDK_DEBUG=1
+#
+# assuming you have 4 cores in the system and you build in the same directory as the Android.mk file
+
+LOCAL_PATH := $(NDK_PROJECT_PATH) # Use NDK_PROJECT_PATH to determine directory with source
+
+# Included in comments is an example on how to also include prebuilt libraries that will provide the PKCS11
+# functionality. These cannot be loaded dynamically in android but have to be "pre-included" when building the jni.
+# The android linker will then automatically load the libraries providing the PKCS11 native functionality.
+##############
+# Build any dependency mylib_prebuilt might have first.
+##############
+#include $(CLEAR_VARS)
+
+#LOCAL_MODULE := mylib_prebuilt_dependency
+#LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/prebuilt_libs/mylib_prebuilt_dependency_include
+#LOCAL_SRC_FILES := $(LOCAL_PATH)/prebuilt_libs/$(TARGET_ARCH_ABI)/libmylib_prebuilt_dependency.so
+#$(info $(LOCAL_SRC_FILES))
+
+#include $(PREBUILT_SHARED_LIBRARY)
+
+#####################
+# Build mylib_prebuilt
+#####################
+#include $(CLEAR_VARS)
+
+#LOCAL_MODULE := mylib_prebuilt
+#LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/prebuilt_libs/mylib_prebuilt_include
+#LOCAL_SRC_FILES := $(LOCAL_PATH)/prebuilt_libs/$(TARGET_ARCH_ABI)/mylib_prebuilt.so
+
+#include $(PREBUILT_SHARED_LIBRARY)
+
+####################
+# Build OpenSC JNI bindings
+####################
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libOpenSCjniAndroid
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) \
+					$(LOCAL_PATH)/jniP11 \
+					$(LOCAL_PATH)/jniP11/opensc \
+					$(LOCAL_PATH)/jnix
+
+# include all c files in subdirs
+PROJECT_FILES := $(wildcard $(LOCAL_PATH)/*.c)
+PROJECT_FILES += $(wildcard $(LOCAL_PATH)/**/*.c)
+PROJECT_FILES += $(wildcard $(LOCAL_PATH)/**/**/*.c)
+
+PROJECT_FILES := $(PROJECT_FILES:$(LOCAL_PATH)/%=%)
+
+LOCAL_SRC_FILES := $(PROJECT_FILES)
+
+LOCAL_CFLAGS := -rdynamic -DANDROID -DOT_LOGGING
+
+LOCAL_SHARED_LIBRARIES := libcutils libc libdl # mylib_prebuilt #mylib_prebuilt_dependency
+LOCAL_STATIC_LIBRARIES := libstlport
+
+LOCAL_LDLIBS := -llog
+
+#ifeq ($(TARGET_ARCH),arm)
+# might be necessary if errors occur only on arm
+#LOCAL_LDFLAGS := -Wl,--hash-style=sysv
+#endif
+
+include $(BUILD_SHARED_LIBRARY)

--- a/jni/build/android/Application.mk
+++ b/jni/build/android/Application.mk
@@ -1,0 +1,7 @@
+APP_STL := gnustl_static
+APP_PLATFORM := android-21
+APP_ABI := armeabi armeabi-v7a x86 #all
+APP_CFLAGS := -g -Wall -O2
+
+APP_BUILD_SCRIPT := ../build/android/Android.mk #assumes it's in the jni/src directory
+NDK_TOOLCHAIN_VERSION := 4.9

--- a/jni/src/jniP11/jniP11private.h
+++ b/jni/src/jniP11/jniP11private.h
@@ -26,6 +26,16 @@
 #include <jnix.h>
 #include <opensc/pkcs11.h>
 
+#ifdef ANDROID 
+#include <android/log.h>
+#define  LOG_TAG    "OpenSC_JNI_BINDINGS"
+#define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
+#define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+#else
+#define LOGD(...) fprintf( stderr, __VA_ARGS__)
+#define LOGE(...) fprintf( stderr, __VA_ARGS__)
+#endif /* ANDROID */
+
 typedef struct pkcs11_module_st pkcs11_module_t;
 
 #define PKCS11_MODULE_MAGIC 0xd0bed0be

--- a/jni/src/jniP11/org_opensc_pkcs11_wrap_PKCS11Session.c
+++ b/jni/src/jniP11/org_opensc_pkcs11_wrap_PKCS11Session.c
@@ -25,7 +25,6 @@
 
 #include <jniP11private.h>
 
-
 /*
  * Populate mechanism structure from Java Object
  */
@@ -100,7 +99,7 @@ JNIEXPORT void JNICALL JNIX_FUNC_NAME(Java_org_opensc_pkcs11_wrap_PKCS11Session_
   rv = mod->method->C_CloseSession(hsession);
   if (rv != CKR_OK)
     {
-      fprintf(stderr,"pkcs11_slot_close_session: C_CloseSession for PKCS11 slot %d(" PKCS11_MOD_NAME_FMT ") failed.",
+      LOGE("pkcs11_slot_close_session: C_CloseSession for PKCS11 slot %d(" PKCS11_MOD_NAME_FMT ") failed.",
               (int)slot->id,mod->name);
     }
 }
@@ -157,7 +156,7 @@ JNIEXPORT void JNICALL JNIX_FUNC_NAME(Java_org_opensc_pkcs11_wrap_PKCS11Session_
   rv = mod->method->C_Logout(hsession);
   if (rv != CKR_OK)
     {
-      fprintf(stderr,"PKCS11Session.logoutNative: C_Logout for PKCS11 slot %d(" PKCS11_MOD_NAME_FMT ") failed (%s).",
+      LOGE("PKCS11Session.logoutNative: C_Logout for PKCS11 slot %d(" PKCS11_MOD_NAME_FMT ") failed (%s).",
               (int)slot->id,mod->name,pkcs11_strerror(rv));
     }
 }
@@ -578,7 +577,6 @@ JNIEXPORT void JNICALL JNIX_FUNC_NAME(Java_org_opensc_pkcs11_wrap_PKCS11Session_
       return;
     }
 }
-
 
 
 

--- a/jni/src/jniP11/pkcs11_module.c
+++ b/jni/src/jniP11/pkcs11_module.c
@@ -102,7 +102,11 @@ static CK_RV pkcs11_unlock_mutex(CK_VOID_PTR pMutex)
 #else
 
 #include <pthread.h>
+#ifdef ANDROID
+#include <dlfcn.h>
+#else
 #include <ltdl.h>
+#endif /* ANDROID */
 
 static CK_RV pkcs11_create_mutex(CK_VOID_PTR_PTR ppMutex)
 {
@@ -234,13 +238,14 @@ pkcs11_module_t *new_pkcs11_module(JNIEnv *env, jstring filename)
       goto failed;
     }
 #else
+#ifndef ANDROID
   if (lt_dlinit() != 0)
     {
       jnixThrowException(env,"org/opensc/pkcs11/wrap/PKCS11Exception",
                          "Unable ot initialize dynamic function loading.");
       return 0;
     }
-
+#endif /* ANDROID */
   getBytesId = (*env)->GetMethodID(env,sc,"getBytes","()[B");
 
   if (!getBytesId) goto failed;
@@ -261,13 +266,20 @@ pkcs11_module_t *new_pkcs11_module(JNIEnv *env, jstring filename)
     
   (*env)->GetByteArrayRegion(env,filename8,0,sz,(jbyte*)mod->name);
   mod->name[sz] = 0;
-
+#ifdef ANDROID
+  mod->handle = dlopen(mod->name, RTLD_NOW);
+#else
   mod->handle = lt_dlopen(mod->name);
-
+#endif /* ANDROID */
   if (mod->handle == NULL)
     {
+#ifdef ANDROID
+      jnixThrowException(env,"org/opensc/pkcs11/wrap/PKCS11Exception",
+                         "Cannot open PKCS11 module %s: %s.",mod->name,dlerror());
+#else
       jnixThrowException(env,"org/opensc/pkcs11/wrap/PKCS11Exception",
                          "Cannot open PKCS11 module %s: %s.",mod->name,lt_dlerror());
+#endif /* ANDROID */
       goto failed;
     }
 #endif
@@ -281,16 +293,28 @@ pkcs11_module_t *new_pkcs11_module(JNIEnv *env, jstring filename)
     	throwWin32Error(env,"Cannot find function C_GetFunctionList in PKCS11 module",mod->name);
       goto failed;
     }
-      
+
+#else
+
+#ifdef ANDROID
+  c_get_function_list = (CK_RV (*)(CK_FUNCTION_LIST_PTR_PTR))
+    dlsym(mod->handle, "C_GetFunctionList");
 #else
   c_get_function_list = (CK_RV (*)(CK_FUNCTION_LIST_PTR_PTR))
     lt_dlsym(mod->handle, "C_GetFunctionList");
-    
+#endif /* ANDROID */
+
   if (!c_get_function_list)
     {
+#ifdef ANDROID
+      jnixThrowException(env,"org/opensc/pkcs11/wrap/PKCS11Exception",
+                         "Cannot find function C_GetFunctionList in PKCS11 module %s: %s.",
+                         mod->name,dlerror());
+#else
       jnixThrowException(env,"org/opensc/pkcs11/wrap/PKCS11Exception",
                          "Cannot find function C_GetFunctionList in PKCS11 module %s: %s.",
                          mod->name,lt_dlerror());
+#endif /* ANDROID */
       goto failed;
     }
 #endif
@@ -323,30 +347,33 @@ pkcs11_module_t *new_pkcs11_module(JNIEnv *env, jstring filename)
     }
 
 #ifdef DEBUG_PKCS11_MODULE
-  fprintf(stderr,"Loaded module: " PKCS11_MOD_NAME_FMT ".\n",mod->name);
-  fprintf(stderr,"handle= %p.\n",mod);
-  fprintf(stderr,"version= %d.%d.\n",
-          (int)mod->ck_info.cryptokiVersion.major,
-          (int)mod->ck_info.cryptokiVersion.minor );
-  fprintf(stderr,"manufacturer= %.32s.\n",mod->ck_info.manufacturerID);
-  fprintf(stderr,"description= %.32s.\n",mod->ck_info.libraryDescription);
+  LOGE("Loaded module: " PKCS11_MOD_NAME_FMT ".\n",mod->name);
+  LOGE("handle= %p.\n",mod);
+  LOGE("version= %d.%d.\n",
+      (int)mod->ck_info.cryptokiVersion.major,
+      (int)mod->ck_info.cryptokiVersion.minor );
+  LOGE("manufacturer= %.32s.\n",mod->ck_info.manufacturerID;
+  LOGE("description= %.32s.\n",mod->ck_info.libraryDescription);
 #endif
 
  return mod;
 
 failed:
   if (mod->name) free(mod->name);
- 
+
+  if (mod->handle) {
 #ifdef WIN32
-  if (mod->handle)
     FreeLibrary(mod->handle);
+#ifdef ANDROID
+    dlclose(mod->handle);
 #else
-  if (mod->handle)
     lt_dlclose(mod->handle);
+#endif /* ANDROID */
 #endif
+  }
   free(mod);
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(ANDROID)
   lt_dlexit();
 #endif
   return 0;
@@ -375,27 +402,30 @@ void destroy_pkcs11_module(JNIEnv *env, pkcs11_module_t *mod)
 {
  
 #ifdef DEBUG_PKCS11_MODULE
-  fprintf(stderr,"Unloading module: " PKCS11_MOD_NAME_FMT ".\n",mod->name);
-  fprintf(stderr,"handle= %p.\n",mod);
+  LOGE("Unloading module: " PKCS11_MOD_NAME_FMT ".\n",mod->name);
+  LOGE("handle= %p.\n",mod);
 #endif
 
   /* Tell the PKCS11 library to shut down */
   mod->method->C_Finalize(NULL);
 
+  if (mod->handle) {
 #ifdef WIN32
-  if (mod->handle)
     FreeLibrary(mod->handle);
 #else
-  if (mod->handle)
+#ifdef ANDROID
+    dlclose(mod->handle);
+#else
     lt_dlclose(mod->handle);
+#endif /* ANDROID */
 #endif
-
+  }
   if (mod->name) free(mod->name);
 
   memset(mod, 0, sizeof(pkcs11_module_t));
   free(mod);
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(ANDROID)
   lt_dlexit();
 #endif
 }

--- a/jni/src/jniP11/pkcs11_slot.c
+++ b/jni/src/jniP11/pkcs11_slot.c
@@ -54,15 +54,15 @@ pkcs11_slot_t *new_pkcs11_slot(JNIEnv *env,  pkcs11_module_t *mod, CK_SLOT_ID id
     }
 
 #ifdef DEBUG_PKCS11_SLOT
-  fprintf(stderr,"Loaded slot: %d.\n",(int)id);
-  fprintf(stderr,"handle= %p.\n",slot);
-  fprintf(stderr,"description= %.64s.\n",slot->ck_slot_info.slotDescription);
-  fprintf(stderr,"manufacturer= %.32s.\n",slot->ck_slot_info.manufacturerID);
-  fprintf(stderr,"flags= %x.\n",(unsigned)slot->ck_slot_info.flags);
-  fprintf(stderr,"hardwareVersion= %d.%d.\n",
+  LOGE("Loaded slot: %d.\n",(int)id);
+  LOGE("handle= %p.\n",slot);
+  LOGE("description= %.64s.\n",slot->ck_slot_info.slotDescription);
+  LOGE("manufacturer= %.32s.\n",slot->ck_slot_info.manufacturerID);
+  LOGE("flags= %x.\n",(unsigned)slot->ck_slot_info.flags);
+  LOGE("hardwareVersion= %d.%d.\n",
           (int)slot->ck_slot_info.hardwareVersion.major,
           (int)slot->ck_slot_info.hardwareVersion.minor );
-  fprintf(stderr,"firmwareVersion= %d.%d.\n",
+  LOGE("firmwareVersion= %d.%d.\n",
           (int)slot->ck_slot_info.firmwareVersion.major,
           (int)slot->ck_slot_info.firmwareVersion.minor );
 #endif
@@ -78,16 +78,16 @@ pkcs11_slot_t *new_pkcs11_slot(JNIEnv *env,  pkcs11_module_t *mod, CK_SLOT_ID id
         }
 
 #ifdef DEBUG_PKCS11_SLOT
-      fprintf(stderr,"token.label= %.32s.\n",slot->ck_token_info.label);
-      fprintf(stderr,"token.manufacturer= %.32s.\n",slot->ck_token_info.manufacturerID);
-      fprintf(stderr,"token.model= %.16s.\n",slot->ck_token_info.model);
-      fprintf(stderr,"token.serialNumber= %.16s.\n",slot->ck_token_info.serialNumber);
-      fprintf(stderr,"token.flags= %x.\n",(unsigned)slot->ck_token_info.flags);
-      fprintf(stderr,"token.ulMaxSessionCount= %u.\n",
+      LOGE("token.label= %.32s.\n",slot->ck_token_info.label);
+      LOGE("token.manufacturer= %.32s.\n",slot->ck_token_info.manufacturerID);
+      LOGE("token.model= %.16s.\n",slot->ck_token_info.model);
+      LOGE("token.serialNumber= %.16s.\n",slot->ck_token_info.serialNumber);
+      LOGE("token.flags= %x.\n",(unsigned)slot->ck_token_info.flags);
+      LOGE("token.ulMaxSessionCount= %u.\n",
               (unsigned)slot->ck_token_info.ulMaxSessionCount);
-      fprintf(stderr,"token.ulMaxPinLen= %u.\n",
+      LOGE("token.ulMaxPinLen= %u.\n",
               (unsigned)slot->ck_token_info.ulMaxPinLen);
-      fprintf(stderr,"token.ulMinPinLen= %u.\n",
+      LOGE("token.ulMinPinLen= %u.\n",
               (unsigned)slot->ck_token_info.ulMinPinLen);
 #endif
     }
@@ -121,8 +121,8 @@ pkcs11_slot_t *pkcs11_slot_from_jhandle(JNIEnv *env, jlong handle)
 void destroy_pkcs11_slot(JNIEnv *env, pkcs11_module_t *mod, pkcs11_slot_t *slot)
 { 
 #ifdef DEBUG_PKCS11_SLOT
-  fprintf(stderr,"Unloading slot: %d.\n",(int)slot->id);
-  fprintf(stderr,"handle= %p.\n",slot);
+  LOGE("Unloading slot: %d.\n",(int)slot->id);
+  LOGE("handle= %p.\n",slot);
 #endif
 
   memset(slot, 0, sizeof(pkcs11_slot_t));


### PR DESCRIPTION
The Android.mk file also has a command for building with ndk-build. 
You must have android-ndk installed and in your $PATH. 
This builds fine but because of how android works any prebuilt libraries that provide the native PKCS11 functionality have to be prebuilt (for android architectures) along with the jni and not loaded on runtime. That's why I've included an example on how to include the *.so files and headers, of any dependencies, in the Android.mk. 

Effectively these changes allow for the usage of the opensc-java bindings in Android apps. 

If anything needs fixing let me know. 
